### PR TITLE
authentication with passwords

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,13 @@
 module github.com/TokiLoshi/chirpy
 
-go 1.22.4
+go 1.23.0
+
+toolchain go1.23.9
 
 require (
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/lib/pq v1.10.9
 )
+
+require golang.org/x/crypto v0.38.0

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,5 @@ github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+golang.org/x/crypto v0.38.0 h1:jt+WWG8IZlBnVbomuhg2Mdq0+BBQaHbtqHEFEigjUV8=
+golang.org/x/crypto v0.38.0/go.mod h1:MvrbAqul58NNYPKnOra203SB9vpuZW0e+RRZV+Ggqjw=

--- a/internal/auth.go
+++ b/internal/auth.go
@@ -1,0 +1,17 @@
+package auth
+
+import (
+	"golang.org/x/crypto/bcrypt"
+)
+
+func HashPassword(password string) (string, error) {
+	
+	bytes, err := bcrypt.GenerateFromPassword([]byte(password), 10)
+	return string(bytes), err
+}
+
+func CheckPasswordHash(hash, password string) error {
+	err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
+
+	return err
+}

--- a/internal/auth_test.go
+++ b/internal/auth_test.go
@@ -1,0 +1,58 @@
+package auth
+
+import (
+	"testing"
+)
+
+func TestCheckPasswordHash(t *testing.T) {
+	password1 := "correctPassword123!"
+	password2 := "anotherPassword456"
+	hash1, _ := HashPassword(password1)
+	hash2, _ := HashPassword(password2)
+
+	tests := []struct {
+		name string
+		password string 
+		hash string 
+		wantErr bool
+	} {
+		{
+			name: "Correct password",
+			password: password1,
+			hash: hash1,
+			wantErr: false,
+		},
+		{
+			name: "Incorrect password",
+			password: "wrongPassword",
+			hash: hash1,
+			wantErr: true,
+		}, 
+		{
+			name: "Password doesn't match different hash",
+			password: password1, 
+			hash: hash2, 
+			wantErr: true,
+		}, 
+		{ 
+			name: "Empty password",
+			password: "",
+			hash: hash1, 
+			wantErr: true,
+		}, 
+		{
+			name: "Invalid hash", 
+			password: password1, 
+			hash: "invalidhash", 
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := CheckPasswordHash(tt.hash, tt.password)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CheckPasswordHash() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/database/models.go
+++ b/internal/database/models.go
@@ -19,8 +19,9 @@ type Chirp struct {
 }
 
 type User struct {
-	ID        uuid.UUID
-	CreatedAt time.Time
-	UpdatedAt time.Time
-	Email     string
+	ID             uuid.UUID
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+	Email          string
+	HashedPassword string
 }

--- a/internal/database/users.sql.go
+++ b/internal/database/users.sql.go
@@ -7,22 +7,30 @@ package database
 
 import (
 	"context"
+
+	"github.com/google/uuid"
 )
 
 const createUser = `-- name: CreateUser :one
-INSERT INTO users(id, created_at, updated_at, email) VALUES(
-  gen_random_uuid(), NOW(), NOW(), $1
-) RETURNING id, created_at, updated_at, email
+INSERT INTO users(id, created_at, updated_at, email, hashed_password) VALUES(
+  gen_random_uuid(), NOW(), NOW(), $1, $2
+) RETURNING id, created_at, updated_at, email, hashed_password
 `
 
-func (q *Queries) CreateUser(ctx context.Context, email string) (User, error) {
-	row := q.db.QueryRowContext(ctx, createUser, email)
+type CreateUserParams struct {
+	Email          string
+	HashedPassword string
+}
+
+func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) (User, error) {
+	row := q.db.QueryRowContext(ctx, createUser, arg.Email, arg.HashedPassword)
 	var i User
 	err := row.Scan(
 		&i.ID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.Email,
+		&i.HashedPassword,
 	)
 	return i, err
 }
@@ -34,4 +42,38 @@ DELETE FROM users
 func (q *Queries) DeleteUsers(ctx context.Context) error {
 	_, err := q.db.ExecContext(ctx, deleteUsers)
 	return err
+}
+
+const getUserByEmail = `-- name: GetUserByEmail :one
+SELECT id, created_at, updated_at, email, hashed_password FROM users WHERE email=$1
+`
+
+func (q *Queries) GetUserByEmail(ctx context.Context, email string) (User, error) {
+	row := q.db.QueryRowContext(ctx, getUserByEmail, email)
+	var i User
+	err := row.Scan(
+		&i.ID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Email,
+		&i.HashedPassword,
+	)
+	return i, err
+}
+
+const getUsers = `-- name: GetUsers :one
+SELECT id, created_at, updated_at, email, hashed_password FROM users WHERE id=$1
+`
+
+func (q *Queries) GetUsers(ctx context.Context, id uuid.UUID) (User, error) {
+	row := q.db.QueryRowContext(ctx, getUsers, id)
+	var i User
+	err := row.Scan(
+		&i.ID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Email,
+		&i.HashedPassword,
+	)
+	return i, err
 }

--- a/main.go
+++ b/main.go
@@ -73,6 +73,7 @@ func main() {
 	mux.HandleFunc("POST /api/chirps", apiCfg.createChirp)
 	mux.HandleFunc("GET /api/chirps", apiCfg.getAllChirps)
 	mux.HandleFunc("GET /api/chirps/{chirpID}", apiCfg.getSingleChirp)
+	mux.HandleFunc("POST /api/login", apiCfg.handleLogin)
 
 	server := &http.Server{
 		Addr: ":" + port,

--- a/sql/queries/users.sql
+++ b/sql/queries/users.sql
@@ -1,7 +1,13 @@
 -- name: CreateUser :one
-INSERT INTO users(id, created_at, updated_at, email) VALUES(
-  gen_random_uuid(), NOW(), NOW(), $1
+INSERT INTO users(id, created_at, updated_at, email, hashed_password) VALUES(
+  gen_random_uuid(), NOW(), NOW(), $1, $2
 ) RETURNING *;
 
 -- name: DeleteUsers :exec 
 DELETE FROM users;
+
+-- name: GetUsers :one 
+SELECT * FROM users WHERE id=$1;
+
+-- name: GetUserByEmail :one 
+SELECT * FROM users WHERE email=$1;

--- a/sql/schema/003_hashedPassword.sql
+++ b/sql/schema/003_hashedPassword.sql
@@ -1,0 +1,2 @@
+-- +goose Up
+ALTER TABLE users ADD hashed_password varchar(255) DEFAULT 'unset' NOT NULL;

--- a/users.go
+++ b/users.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"time"
 
+	auth "github.com/TokiLoshi/chirpy/internal"
+	"github.com/TokiLoshi/chirpy/internal/database"
 	"github.com/google/uuid"
 )
 
@@ -18,6 +20,7 @@ type User struct {
 func (cfg *apiConfig) validateUser(w http.ResponseWriter, req *http.Request) {
 	type parameters struct {
 		Email string `json:"email"`
+		Password string `json:"password"`
 	}
 
 	decoder := json.NewDecoder(req.Body)
@@ -30,14 +33,24 @@ func (cfg *apiConfig) validateUser(w http.ResponseWriter, req *http.Request) {
 	}
 
 	userEmail := params.Email
+	userPassword := params.Password 
 
-	dbUser, err := cfg.dbQueries.CreateUser(req.Context(), userEmail)
+	hashedPassword, err := auth.HashPassword(userPassword)
+
+	if err != nil {
+		respondWithError(w, 500, "unable to hash password")
+	}
+
+	dbUser, err := cfg.dbQueries.CreateUser(req.Context(), database.CreateUserParams{
+		Email: userEmail, 
+		HashedPassword: hashedPassword,
+	})
+
 	if err != nil {
 		respondWithError(w, 400, "couldn't create user: " + err.Error() )
 		return
 		} 
 	
-
 	user := User {
 		ID: dbUser.ID,
 		Email: dbUser.Email,
@@ -46,5 +59,48 @@ func (cfg *apiConfig) validateUser(w http.ResponseWriter, req *http.Request) {
 	}
 
 	respondWithJson(w, 201, user)
+
+}
+
+func (cfg *apiConfig) handleLogin(w http.ResponseWriter, req *http.Request) {
+	type parameters struct {
+		Email string `json:"email"`
+		Password string `json:"password"`
+	}
+	decoder := json.NewDecoder(req.Body)
+	params := parameters{}
+
+	err := decoder.Decode(&params)
+	if err != nil {
+		respondWithError(w, 400, "error decoding json data")
+		return
+	}
+
+	userEmail := params.Email 
+	userPassword := params.Password 
+
+	userEntry, err := cfg.dbQueries.GetUserByEmail(req.Context(), userEmail)
+
+	if err != nil {
+		respondWithError(w, 401, "Unauthorized")
+		return
+	}
+
+	error := auth.CheckPasswordHash(userEntry.HashedPassword, userPassword)
+
+	if error != nil {
+		respondWithError(w, 401, "Unauthorized")
+		return
+	}
+
+	user := User{
+		ID: userEntry.ID,
+		Email: userEntry.Email, 
+		CreatedAt: userEntry.CreatedAt, 
+		UpdatedAt: userEntry.UpdatedAt,
+
+	}
+
+	respondWithJson(w, 200, user)
 
 }


### PR DESCRIPTION
Adding authentication password hashing and comparison with bcrypt. 
1. Added migration to store hashed_password in the database
2. Created internal authentication to expose generateHash and compare hashed password 
3. Added simple unit tests
4. Updated users endpoint to require password field 
5. Added login end point
6. Added new query to check user email and if user exists to check the hash